### PR TITLE
fix(core-api-response): added missing functions

### DIFF
--- a/src/Types/Sdk/CoreApiResponse.php
+++ b/src/Types/Sdk/CoreApiResponse.php
@@ -83,4 +83,20 @@ abstract class CoreApiResponse
     {
         return $this->body;
     }
+
+    /**
+     * Is response OK?
+     */
+    public function isSuccess(): bool
+    {
+        return $this->statusCode !== null && $this->statusCode == min(max($this->statusCode, 200), 299);
+    }
+
+    /**
+     * Is response missing or not OK?
+     */
+    public function isError(): bool
+    {
+        return !$this->isSuccess();
+    }
 }

--- a/src/Types/Sdk/CoreApiResponse.php
+++ b/src/Types/Sdk/CoreApiResponse.php
@@ -89,7 +89,16 @@ abstract class CoreApiResponse
      */
     public function isSuccess(): bool
     {
-        return $this->statusCode !== null && $this->statusCode == min(max($this->statusCode, 200), 299);
+        if ($this->statusCode == null) {
+            return false;
+        }
+        if ($this->statusCode < 200) {
+            return false;
+        }
+        if ($this->statusCode > 299) {
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/tests/ApiCallTest.php
+++ b/tests/ApiCallTest.php
@@ -780,16 +780,16 @@ class ApiCallTest extends TestCase
             '"retryOption":"useGlobalSettings"},"additionalProperties":[]}', $result->getBody());
         $this->assertEquals(['content-type' => 'application/json'], $result->getHeaders());
         $this->assertEquals(200, $result->getStatusCode());
+        $this->assertTrue($result->isSuccess());
         $this->assertNull($result->getReasonPhrase());
     }
 
-    public function testNullOn404()
+    public function testResponseMissingInApiResponse()
     {
-        $response = new MockResponse();
-        $response->setStatusCode(404);
-        $context = new Context(MockHelper::getClient()->getGlobalRequest(), $response, MockHelper::getClient());
-        $result = MockHelper::responseHandler()->nullOn404()->getResult($context);
-        $this->assertNull($result);
+        $mockRequest = MockHelper::getClient()->getGlobalRequest()->convert();
+        $response = new MockApiResponse($mockRequest, null, null, null, null, null);
+        $this->assertInstanceOf(MockRequest::class, $response->getRequest());
+        $this->assertTrue($response->isError());
     }
 
     public function testApiResponseWith400()
@@ -800,6 +800,16 @@ class ApiCallTest extends TestCase
         $result = MockHelper::responseHandler()->type(MockClass::class)->returnApiResponse()->getResult($context);
         $this->assertInstanceOf(MockApiResponse::class, $result);
         $this->assertEquals(['res' => 'This is raw body'], $result->getResult());
+        $this->assertTrue($result->isError());
+    }
+
+    public function testNullOn404()
+    {
+        $response = new MockResponse();
+        $response->setStatusCode(404);
+        $context = new Context(MockHelper::getClient()->getGlobalRequest(), $response, MockHelper::getClient());
+        $result = MockHelper::responseHandler()->nullOn404()->getResult($context);
+        $this->assertNull($result);
     }
 
     public function testGlobalMockException()

--- a/tests/ApiCallTest.php
+++ b/tests/ApiCallTest.php
@@ -803,6 +803,17 @@ class ApiCallTest extends TestCase
         $this->assertTrue($result->isError());
     }
 
+    public function testApiResponseWith100()
+    {
+        $response = new MockResponse();
+        $response->setStatusCode(100);
+        $context = new Context(MockHelper::getClient()->getGlobalRequest(), $response, MockHelper::getClient());
+        $result = MockHelper::responseHandler()->type(MockClass::class)->returnApiResponse()->getResult($context);
+        $this->assertInstanceOf(MockApiResponse::class, $result);
+        $this->assertEquals(['res' => 'This is raw body'], $result->getResult());
+        $this->assertTrue($result->isError());
+    }
+
     public function testNullOn404()
     {
         $response = new MockResponse();


### PR DESCRIPTION
Added missing functions `isSuccess` and `isError` and covered them using unit tests
Closes #9 