### PR TITLE
fix(invalid-content-type): null body should not have content-type header

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
          backupStaticAttributes="false"
          bootstrap="tests/bootstrap.php"
          colors="true"
@@ -11,15 +12,16 @@
          stopOnError="false"
          stopOnFailure="false"
          verbose="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
 >
     <testsuites>
         <testsuite name="SDK Test Suite">
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
+    <coverage includeUncoveredFiles="true">
+        <include>
             <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -235,6 +235,11 @@ class Request implements RequestSetterInterface
         if (!empty($this->parameters)) {
             return;
         }
+
+        if (is_null($this->body)) {
+            return;
+        }
+
         $this->addContentType($format);
         $this->body = Closure::fromCallable($serializer)($this->body);
     }


### PR DESCRIPTION
This PR bears a fix for the case when request body is null but the content-type header is being added unless specified in the spec.  This commit address the fix for this and does not allow to add content-type header for null body request.

closes #19 