### PR TITLE
ci(release-workflow): updates release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,11 @@
 name: Release To Packagist
-run-name: ${{ github.event.inputs.Title }} (${{ github.event.inputs.Version }})
+run-name: Publishing Package Version ${{ github.event.inputs.Version }}
 on:
   workflow_dispatch:
     inputs:
       Version:
-        description: "Version to be released in format: x.y.z, where x => major version, y => minor version and z => patch version"
+        description: "This input field requires version in format: x.y.z, where x => major version, y => minor version and z => patch version"
         required: true
-        default: "0.1.0"
-      Title:
-        description: "Title of the release"
-        required: true
-        default: "Improving API developer experience"
 jobs:
   create-release:
     name: Creating release version ${{ github.event.inputs.Version }}
@@ -31,5 +26,5 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
-          name: ${{ github.event.inputs.Title }}
+          name: Release Version ${{ github.event.inputs.Version }}
           body: ${{ steps.tag_version.outputs.changelog }}


### PR DESCRIPTION
This commit updates the release workflow, removes the title field from the input, and updates the run-name for the action.