### PR TITLE
feat(multiple-auth): added multiple auth implementation and exception handling

### DIFF
--- a/src/Authentication/Auth.php
+++ b/src/Authentication/Auth.php
@@ -32,20 +32,24 @@ class Auth implements AuthInterface
     }
 
     /**
-     * @var array
+     * @var array<Auth|string>
      */
     private $auths;
 
     /**
-     * @var array<string,AuthInterface>
+     * @var AuthInterface[]
      */
-    private $authGroups = [];
+    private $selectedAuthGroups = [];
+
+    /**
+     * @var AuthInterface[]
+     */
+    private $validatedAuthGroups = [];
 
     /**
      * @var string
      */
     private $groupType;
-    private $isValid = false;
 
     /**
      * @param array $auths
@@ -62,7 +66,7 @@ class Auth implements AuthInterface
      */
     public function withAuthManagers(array $authManagers): self
     {
-        $this->authGroups = array_map(function ($auth) use ($authManagers) {
+        $this->selectedAuthGroups = array_map(function ($auth) use ($authManagers) {
             if (is_string($auth) && isset($authManagers[$auth])) {
                 return $authManagers[$auth];
             } elseif ($auth instanceof Auth) {
@@ -74,35 +78,32 @@ class Auth implements AuthInterface
     }
 
     /**
-     * @throws InvalidArgumentException
+     * @throws AuthValidationException
      */
     public function validate(TypeValidatorInterface $validator): void
     {
-        $success = empty($this->authGroups);
-        $errors = array_map(function ($authGroup) use ($validator, &$success) {
+        $this->validatedAuthGroups = [];
+        $errors = array_filter(array_map(function ($authGroup) use ($validator) {
             try {
                 $authGroup->validate($validator);
-                if ($this->groupType == AuthGroup::OR) {
-                    $success = true;
+                if ($this->groupType == AuthGroup::AND || empty($this->validatedAuthGroups)) {
+                    // Add all authGroups as validated in AND group
+                    // but only the first one in OR group
+                    $this->validatedAuthGroups[] = $authGroup;
                 }
                 return false;
             } catch (InvalidArgumentException $e) {
-                if ($this->groupType == AuthGroup::AND) {
-                    throw $e;
-                }
                 return $e->getMessage();
             }
-        }, $this->authGroups);
-        if ($success) {
-            $this->isValid = true;
+        }, $this->selectedAuthGroups));
+
+        if (empty($errors) || ($this->groupType == AuthGroup::OR && !empty($this->validatedAuthGroups))) {
             return;
         }
-        if ($this->groupType == AuthGroup::AND) {
-            $this->isValid = true;
-            return;
-        }
-        throw new InvalidArgumentException("Missing required auth credentials:\n-> " .
-            join("\n-> ", array_filter($errors)));
+
+        // throw exception if unable to apply Any Single authentication in AND group
+        // OR if unable to apply All authentication in OR group
+        throw AuthValidationException::init($errors);
     }
 
     /**
@@ -110,12 +111,9 @@ class Auth implements AuthInterface
      */
     public function apply(RequestSetterInterface $request): void
     {
-        if (!$this->isValid) {
-            return;
-        }
-        $this->authGroups = array_map(function ($authGroup) use ($request) {
+        $this->validatedAuthGroups = array_map(function ($authGroup) use ($request) {
             $authGroup->apply($request);
             return $authGroup;
-        }, $this->authGroups);
+        }, $this->validatedAuthGroups);
     }
 }

--- a/src/Authentication/Auth.php
+++ b/src/Authentication/Auth.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Core\Authentication;
 
+use Core\Exceptions\AuthValidationException;
 use CoreInterfaces\Core\Authentication\AuthGroup;
 use CoreInterfaces\Core\Authentication\AuthInterface;
 use CoreInterfaces\Core\Request\RequestSetterInterface;

--- a/src/Authentication/AuthValidationException.php
+++ b/src/Authentication/AuthValidationException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Core\Authentication;
+
+use InvalidArgumentException;
+
+/**
+ * Authentication Validation Exception.
+ */
+class AuthValidationException extends InvalidArgumentException
+{
+    private const ERROR_MESSAGE_PREFIX = "Following authentication credentials are required:\n-> ";
+
+    /**
+     * Initialize a new instance of AuthValidationException
+     *
+     * @param string[] $errors An array of errors in authentication validation
+     */
+    public static function init(array $errors): AuthValidationException
+    {
+        return new self(self::ERROR_MESSAGE_PREFIX . join("\n-> ", $errors));
+    }
+}

--- a/src/Exceptions/AuthValidationException.php
+++ b/src/Exceptions/AuthValidationException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Core\Authentication;
+namespace Core\Exceptions;
 
 use InvalidArgumentException;
 

--- a/tests/AuthenticationTest.php
+++ b/tests/AuthenticationTest.php
@@ -7,6 +7,7 @@ use Core\Authentication\AuthValidationException;
 use Core\Request\Request;
 use Core\Tests\Mocking\Authentication\HeaderAuthManager;
 use Core\Tests\Mocking\MockHelper;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class AuthenticationTest extends TestCase
@@ -114,7 +115,8 @@ class AuthenticationTest extends TestCase
     public function testHeaderWithMissingFieldAndQueryAuth()
     {
         $this->expectException(AuthValidationException::class);
-        $this->expectExceptionMessage("Missing required header field: authorization");
+        $this->expectExceptionMessage("Following authentication credentials are required:" .
+            "\n-> Missing required header field: authorization");
 
         $auth = Auth::and('headerWithNull', 'query');
         MockHelper::getClient()->validateAuth($auth);
@@ -123,7 +125,8 @@ class AuthenticationTest extends TestCase
     public function testHeaderAndQueryAuthWithMissingFields()
     {
         $this->expectException(AuthValidationException::class);
-        $this->expectExceptionMessage("Missing required header field: authorization");
+        $this->expectExceptionMessage("Following authentication credentials are required:" .
+            "\n-> Missing required header field: authorization");
 
         $auth = Auth::and('headerWithNull', 'queryWithNull');
         MockHelper::getClient()->validateAuth($auth);
@@ -187,7 +190,7 @@ class AuthenticationTest extends TestCase
     public function testFormOrHeaderWithNullAndHeaderOrQueryWithNull()
     {
         $request = new Request('http://localhost:3000');
-        $auth = Auth::and(Auth::or('form', 'headerWithNull', 'formWithNull'), Auth::or('header', 'queryWithNull'));
+        $auth = Auth::and(Auth::or('form', 'headerWithNull', 'formWithNull'), Auth::or('queryWithNull', 'header'));
         MockHelper::getClient()->validateAuth($auth)->apply($request);
 
         $this->assertEquals([
@@ -204,7 +207,8 @@ class AuthenticationTest extends TestCase
     public function testFormOrHeaderWithNullAndHeaderAndQueryWithNull()
     {
         $this->expectException(AuthValidationException::class);
-        $this->expectExceptionMessage("Missing required query field: token");
+        $this->expectExceptionMessage("Following authentication credentials are required:" .
+            "\n-> Missing required query field: token");
 
         $auth = Auth::and(Auth::or('form', 'headerWithNull'), Auth::and('header', 'queryWithNull'));
         MockHelper::getClient()->validateAuth($auth);
@@ -212,7 +216,7 @@ class AuthenticationTest extends TestCase
 
     public function testInvalidAuthName()
     {
-        $this->expectException(AuthValidationException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("AuthManager not found with name: \"myAuth\"");
 
         MockHelper::getClient()->validateAuth(Auth::or('myAuth'));

--- a/tests/AuthenticationTest.php
+++ b/tests/AuthenticationTest.php
@@ -3,7 +3,7 @@
 namespace Core\Tests;
 
 use Core\Authentication\Auth;
-use Core\Authentication\AuthValidationException;
+use Core\Exceptions\AuthValidationException;
 use Core\Request\Request;
 use Core\Tests\Mocking\Authentication\HeaderAuthManager;
 use Core\Tests\Mocking\MockHelper;


### PR DESCRIPTION
## What
This PR adds the following changes:
- Add the public user-facing changes for multiple auth in RequestBuilder
- Add support for combining authentication credentials as AND/OR groups
- Add unit tests to cover this feature

## Why
We were required to add multiple auth support

Closes #43 

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [x] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
