### PR TITLE
fix(rfc3339-timezone-info): added support for -ve timezones for rfc3339

### DIFF
--- a/src/Utils/DateHelper.php
+++ b/src/Utils/DateHelper.php
@@ -379,8 +379,9 @@ class DateHelper
         if (is_null($date)) {
             return null;
         }
+
         // Check for timezone information and append it if missing
-        if (substr($date, strlen($date) - 1) !== 'Z' && strpos($date, '+') === false) {
+        if (empty(preg_match("/T.*[+-]|T.*Z/", $date))) {
             $date .= 'Z';
         }
 

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -323,6 +323,21 @@ class UtilsTest extends TestCase
             null], $res);
     }
 
+    public function testAddingTimezoneInRFC3339DateString()
+    {
+        $date = DateHelper::fromRfc3339DateTime("2021-10-01T00:00:00");
+        $this->assertEquals("2021-10-01T00:00:00+00:00", DateHelper::toRfc3339DateTime($date));
+
+        $date = DateHelper::fromRfc3339DateTime("2021-10-01T00:00:00Z");
+        $this->assertEquals("2021-10-01T00:00:00+00:00", DateHelper::toRfc3339DateTime($date));
+
+        $date = DateHelper::fromRfc3339DateTime("2021-10-01T00:00:00+01:00");
+        $this->assertEquals("2021-09-30T23:00:00+00:00", DateHelper::toRfc3339DateTime($date));
+
+        $date = DateHelper::fromRfc3339DateTime("2021-10-01T00:00:00-01:00");
+        $this->assertEquals("2021-10-01T01:00:00+00:00", DateHelper::toRfc3339DateTime($date));
+    }
+
     public function testFromRFC3339DateString()
     {
         $this->assertNull(DateHelper::fromRfc3339DateTimeMapOfArray(null));


### PR DESCRIPTION
## What
This PR added support for datetime formats of RFC3339 standards such as `2021-10-01T00:00:00-01:00`

## Why
We are unable to deserialize datetimes strings like 2021-10-01T00:00:00-01:00 earlier

Closes #45

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [x] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
