### PR TITLE
fix(simple-date): added fix for simple date deserialization

### DIFF
--- a/src/Utils/DateHelper.php
+++ b/src/Utils/DateHelper.php
@@ -87,7 +87,7 @@ class DateHelper
         }
         $x = DateTime::createFromFormat(static::SIMPLE_DATE, $date);
         if ($x instanceof DateTime) {
-            return $x;
+            return $x->setTime(0, 0);
         }
         throw new InvalidArgumentException('Incorrect format.');
     }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -301,6 +301,12 @@ class UtilsTest extends TestCase
             null], DateHelper::toSimpleDate2DArray($res));
     }
 
+    public function testFromSimpleDateStringTimeInfo()
+    {
+        $date = DateHelper::fromSimpleDate('2024-01-16');
+        $this->assertEquals(strtotime('2024-01-16'), $date->getTimestamp());
+    }
+
     public function testFromRFC1123DateString()
     {
         $this->assertNull(DateHelper::fromRfc1123DateTimeMapOfArray(null));


### PR DESCRIPTION
## What
This PR removes the incorrect time information from the Simple DateTime instances created via DateHelper::fromSimpleDate.

## Why
DateHelper::fromSimpleDate utility function is supposed to create a DateTime instance only using the string format Y-m-d without time information

Closes #47 

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
