### PR TITLE
fix: validated query url after adding applying global params

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -87,11 +87,9 @@ class Client
 
     public function getGlobalRequest(?string $server = null): Request
     {
-        $request = new Request($this->serverUrls[$server ?? $this->defaultServer], $this);
-        $paramGroup = new MultipleParams('Global Parameters');
-        $paramGroup->parameters($this->globalConfig)->validate(self::getJsonHelper($this));
-        $paramGroup->apply($request);
-        return $request;
+        $globalParams = new MultipleParams('Global Parameters');
+        $globalParams->parameters($this->globalConfig)->validate(self::getJsonHelper($this));
+        return new Request($this->serverUrls[$server ?? $this->defaultServer], $this, $globalParams);
     }
 
     public function getGlobalResponseHandler(): ResponseHandler

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -37,7 +37,7 @@ class Request implements RequestSetterInterface
         if ($globalParams != null) {
             $globalParams->apply($this);
         }
-        CoreHelper::validateUrl($this->queryUrl);
+        $this->queryUrl = CoreHelper::validateUrl($this->queryUrl);
     }
 
     /**

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -6,6 +6,7 @@ namespace Core\Request;
 
 use Closure;
 use Core\Client;
+use Core\Request\Parameters\MultipleParams;
 use Core\Types\Sdk\CoreFileWrapper;
 use Core\Utils\CoreHelper;
 use CoreInterfaces\Core\Format;
@@ -29,10 +30,14 @@ class Request implements RequestSetterInterface
     /**
      * Creates a new Request object.
      */
-    public function __construct(string $queryUrl, ?Client $client = null)
+    public function __construct(string $queryUrl, ?Client $client = null, ?MultipleParams $globalParams = null)
     {
-        $this->queryUrl = CoreHelper::validateUrl($queryUrl);
+        $this->queryUrl = $queryUrl;
         $this->converter = Client::getConverter($client);
+        if ($globalParams != null) {
+            $globalParams->apply($this);
+        }
+        CoreHelper::validateUrl($this->queryUrl);
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -241,4 +241,30 @@ class ClientTest extends TestCase
             Client::getJsonHelper(MockHelper::getClient())
         );
     }
+
+    public function testRequestInitializationWithCustomBaseUrl()
+    {
+        $customUrl = 'https://my/path/';
+        $customUrlWithoutSlash = 'https://my/path';
+
+        $client = ClientBuilder::init(new MockHttpClient())
+            ->converter(new MockConverter())
+            ->apiCallback(MockHelper::getCallbackCatcher())
+            ->jsonHelper(MockHelper::getJsonHelper())
+            ->serverUrls([
+                'ServerA' => '{custom-url-a}',
+                'ServerB' => '{custom-url-b}',
+            ], 'ServerA')
+            ->globalConfig([
+                TemplateParam::init('custom-url-a', $customUrl)->dontEncode(),
+                TemplateParam::init('custom-url-b', $customUrlWithoutSlash)->dontEncode()
+            ])
+            ->build();
+
+        $requestA = $client->getGlobalRequest('ServerA');
+        $this->assertEquals($customUrlWithoutSlash, $requestA->getQueryUrl());
+
+        $requestB = $client->getGlobalRequest('ServerB');
+        $this->assertEquals($customUrlWithoutSlash, $requestB->getQueryUrl());
+    }
 }


### PR DESCRIPTION
## What
This PR fixes a bug where developers were unable to initialize the Request instance using a `{custom-url}` placeholder as the default queryUrl.

## Why
We were required to fix the `Invalid URL format Exception` that was being thrown on such request initialization

Closes #49 

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
