### PR TITLE
fix: throws actual exceptions instead of their wrappers

### DIFF
--- a/src/Response/Types/DeserializableType.php
+++ b/src/Response/Types/DeserializableType.php
@@ -4,7 +4,6 @@ namespace Core\Response\Types;
 
 use Closure;
 use Core\Response\Context;
-use Throwable;
 
 class DeserializableType
 {
@@ -29,10 +28,6 @@ class DeserializableType
         if (is_null($this->deserializerMethod)) {
             return null;
         }
-        try {
-            return Closure::fromCallable($this->deserializerMethod)($context->getResponse()->getBody());
-        } catch (Throwable $t) {
-            throw $context->toApiException($t->getMessage());
-        }
+        return Closure::fromCallable($this->deserializerMethod)($context->getResponse()->getBody());
     }
 }

--- a/src/Response/Types/ResponseType.php
+++ b/src/Response/Types/ResponseType.php
@@ -6,7 +6,6 @@ namespace Core\Response\Types;
 
 use Closure;
 use Core\Response\Context;
-use Exception;
 
 class ResponseType
 {
@@ -57,20 +56,16 @@ class ResponseType
         if (is_null($this->responseClass)) {
             return null;
         }
-        try {
-            if (isset($this->xmlDeserializer)) {
-                return Closure::fromCallable($this->xmlDeserializer)(
-                    $context->getResponse()->getRawBody(),
-                    $this->responseClass
-                );
-            }
-            return $context->getJsonHelper()->mapClass(
-                $context->getResponse()->getBody(),
-                $this->responseClass,
-                $this->dimensions
+        if (isset($this->xmlDeserializer)) {
+            return Closure::fromCallable($this->xmlDeserializer)(
+                $context->getResponse()->getRawBody(),
+                $this->responseClass
             );
-        } catch (Exception $e) {
-            throw $context->toApiException($e->getMessage());
         }
+        return $context->getJsonHelper()->mapClass(
+            $context->getResponse()->getBody(),
+            $this->responseClass,
+            $this->dimensions
+        );
     }
 }

--- a/tests/ApiCallTest.php
+++ b/tests/ApiCallTest.php
@@ -3,6 +3,7 @@
 namespace Core\Tests;
 
 use apimatic\jsonmapper\AnyOfValidationException;
+use apimatic\jsonmapper\JsonMapperException;
 use apimatic\jsonmapper\OneOfValidationException;
 use Core\Request\Parameters\AdditionalFormParams;
 use Core\Request\Parameters\AdditionalQueryParams;
@@ -29,6 +30,7 @@ use CoreInterfaces\Core\Request\RequestMethod;
 use CoreInterfaces\Http\RetryOption;
 use CURLFile;
 use Exception;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class ApiCallTest extends TestCase
@@ -766,7 +768,7 @@ class ApiCallTest extends TestCase
 
     public function testReceiveByWrongType()
     {
-        $this->expectException(MockException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('JsonMapper::mapClass() requires second argument to be a class name, ' .
             'InvalidClass given.');
         MockHelper::newApiCall()
@@ -786,7 +788,7 @@ class ApiCallTest extends TestCase
 
     public function testReceiveByWrongDeserializerMethod()
     {
-        $this->expectException(MockException::class);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('Invalid argument found');
         MockHelper::newApiCall()
             ->requestBuilder((new RequestBuilder(RequestMethod::POST, '/simple/{tyu}')))
@@ -1326,7 +1328,7 @@ class ApiCallTest extends TestCase
 
     public function testTypeXmlFailure()
     {
-        $this->expectException(MockException::class);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage(
             'Required value not found at XML path "/mockClass/new1[1]" during deserialization.'
         );
@@ -1349,7 +1351,7 @@ class ApiCallTest extends TestCase
 
     public function testTypeInvalidJsonFailure()
     {
-        $this->expectException(MockException::class);
+        $this->expectException(JsonMapperException::class);
         $this->expectExceptionMessage(
             'Could not find required constructor arguments for Core\Tests\Mocking\Other\MockClass: body'
         );


### PR DESCRIPTION
## What
This PR removes the redundant wrapping of actual exceptions, by removing the try catch blocks in response handlers

## Why
Exception wrapper class was hiding the actual error and stack trace, making it harder for developers to debug

Closes #52 

## Type of change
Select multiple if applicable.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [X] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
N/A

## Breaking change
This PR is updating the throwable type. It will effect the cases where API calls was not successful in the first place. This made this change categorize as `bug fix`. So it should be released as a minor version.

This change may un-hide the bugs in consumer applications because of broken contract between server and SDKs

## Testing
Unit tests were updated to test the required use cases

## Checklist
- [X] My code follows the coding conventions
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added new unit tests
