### PR TITLE
feat: add support for nullable response types

### DIFF
--- a/src/Response/Context.php
+++ b/src/Response/Context.php
@@ -66,6 +66,15 @@ class Context implements ContextInterface
     }
 
     /**
+     * Is response body missing.
+     */
+    public function isBodyMissing(): bool
+    {
+        $rawBody = $this->response->getRawBody();
+        return $rawBody === '';
+    }
+
+    /**
      * Returns JsonHelper object.
      */
     public function getJsonHelper(): JsonHelper

--- a/src/Response/Context.php
+++ b/src/Response/Context.php
@@ -71,7 +71,7 @@ class Context implements ContextInterface
     public function isBodyMissing(): bool
     {
         $rawBody = $this->response->getRawBody();
-        return $rawBody === '';
+        return trim($rawBody) === '';
     }
 
     /**

--- a/src/Response/Types/ResponseMultiType.php
+++ b/src/Response/Types/ResponseMultiType.php
@@ -39,7 +39,7 @@ class ResponseMultiType
      */
     public function getFrom(Context $context)
     {
-        if (is_null($this->typeGroup)) {
+        if (is_null($this->typeGroup) || $context->isBodyMissing()) {
             return null;
         }
         $responseBody = $context->getResponse()->getBody();

--- a/src/Response/Types/ResponseType.php
+++ b/src/Response/Types/ResponseType.php
@@ -53,7 +53,7 @@ class ResponseType
      */
     public function getFrom(Context $context)
     {
-        if (is_null($this->responseClass)) {
+        if (is_null($this->responseClass) || $context->isBodyMissing()) {
             return null;
         }
         if (isset($this->xmlDeserializer)) {

--- a/tests/ApiCallTest.php
+++ b/tests/ApiCallTest.php
@@ -955,6 +955,16 @@ class ApiCallTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function testNullableTypeWithWhiteSpacedBody()
+    {
+        $response = new MockResponse();
+        $response->setStatusCode(200);
+        $response->setBody('  ');
+        $context = new Context(MockHelper::getClient()->getGlobalRequest(), $response, MockHelper::getClient());
+        $result = MockHelper::responseHandler()->nullableType()->getResult($context);
+        $this->assertNull($result);
+    }
+
     public function testNullableTypeWithBody()
     {
         $response = new MockResponse();
@@ -973,6 +983,16 @@ class ApiCallTest extends TestCase
         $context = new Context(MockHelper::getClient()->getGlobalRequest(), $response, MockHelper::getClient());
         $result = MockHelper::responseHandler()->getResult($context);
         $this->assertEquals('', $result);
+    }
+
+    public function testNonNullableTypeWithWhiteSpacedBody()
+    {
+        $response = new MockResponse();
+        $response->setStatusCode(200);
+        $response->setBody('  ');
+        $context = new Context(MockHelper::getClient()->getGlobalRequest(), $response, MockHelper::getClient());
+        $result = MockHelper::responseHandler()->getResult($context);
+        $this->assertEquals('  ', $result);
     }
 
     public function testNonNullableTypeWithMissingBodyAndApiResponse()

--- a/tests/ApiCallTest.php
+++ b/tests/ApiCallTest.php
@@ -35,6 +35,8 @@ use PHPUnit\Framework\TestCase;
 
 class ApiCallTest extends TestCase
 {
+    private const DUMMY_BODY = ['res' => 'This is raw body'];
+
     /**
      * @param string $query Just the query path of the url
      * @return array<string,string>
@@ -864,11 +866,11 @@ class ApiCallTest extends TestCase
     {
         $response = new MockResponse();
         $response->setStatusCode(400);
-        $response->setBody(['res' => 'This is raw body']);
+        $response->setBody(self::DUMMY_BODY);
         $context = new Context(MockHelper::getClient()->getGlobalRequest(), $response, MockHelper::getClient());
         $result = MockHelper::responseHandler()->type(MockClass::class)->returnApiResponse()->getResult($context);
         $this->assertInstanceOf(MockApiResponse::class, $result);
-        $this->assertEquals(['res' => 'This is raw body'], $result->getResult());
+        $this->assertEquals(self::DUMMY_BODY, $result->getResult());
         $this->assertTrue($result->isError());
     }
 
@@ -876,11 +878,11 @@ class ApiCallTest extends TestCase
     {
         $response = new MockResponse();
         $response->setStatusCode(100);
-        $response->setBody(['res' => 'This is raw body']);
+        $response->setBody(self::DUMMY_BODY);
         $context = new Context(MockHelper::getClient()->getGlobalRequest(), $response, MockHelper::getClient());
         $result = MockHelper::responseHandler()->type(MockClass::class)->returnApiResponse()->getResult($context);
         $this->assertInstanceOf(MockApiResponse::class, $result);
-        $this->assertEquals(['res' => 'This is raw body'], $result->getResult());
+        $this->assertEquals(self::DUMMY_BODY, $result->getResult());
         $this->assertTrue($result->isError());
     }
 

--- a/tests/ApiCallTest.php
+++ b/tests/ApiCallTest.php
@@ -864,6 +864,7 @@ class ApiCallTest extends TestCase
     {
         $response = new MockResponse();
         $response->setStatusCode(400);
+        $response->setBody(['res' => 'This is raw body']);
         $context = new Context(MockHelper::getClient()->getGlobalRequest(), $response, MockHelper::getClient());
         $result = MockHelper::responseHandler()->type(MockClass::class)->returnApiResponse()->getResult($context);
         $this->assertInstanceOf(MockApiResponse::class, $result);
@@ -875,6 +876,7 @@ class ApiCallTest extends TestCase
     {
         $response = new MockResponse();
         $response->setStatusCode(100);
+        $response->setBody(['res' => 'This is raw body']);
         $context = new Context(MockHelper::getClient()->getGlobalRequest(), $response, MockHelper::getClient());
         $result = MockHelper::responseHandler()->type(MockClass::class)->returnApiResponse()->getResult($context);
         $this->assertInstanceOf(MockApiResponse::class, $result);
@@ -919,6 +921,90 @@ class ApiCallTest extends TestCase
         $response->setStatusCode(400);
         $context = new Context(MockHelper::getClient()->getGlobalRequest(), $response, MockHelper::getClient());
         MockHelper::responseHandler()->nullOn404()->getResult($context);
+    }
+
+    public function testNullableTypeWithMissingBody()
+    {
+        $response = new MockResponse();
+        $response->setStatusCode(200);
+        $response->setBody('');
+        $context = new Context(MockHelper::getClient()->getGlobalRequest(), $response, MockHelper::getClient());
+        $result = MockHelper::responseHandler()->nullableType()->getResult($context);
+        $this->assertNull($result);
+    }
+
+    public function testNullableTypeWithMissingBodyAndApiResponse()
+    {
+        $response = new MockResponse();
+        $response->setStatusCode(200);
+        $response->setBody('');
+        $context = new Context(MockHelper::getClient()->getGlobalRequest(), $response, MockHelper::getClient());
+        $result = MockHelper::responseHandler()->nullableType()->returnApiResponse()->getResult($context);
+        $this->assertInstanceOf(MockApiResponse::class, $result);
+        $this->assertNull($result->getResult());
+        $this->assertFalse($result->isError());
+    }
+
+    public function testNullableTypeWithNullBody()
+    {
+        $response = new MockResponse();
+        $response->setStatusCode(200);
+        $response->setBody(null);
+        $context = new Context(MockHelper::getClient()->getGlobalRequest(), $response, MockHelper::getClient());
+        $result = MockHelper::responseHandler()->nullableType()->getResult($context);
+        $this->assertNull($result);
+    }
+
+    public function testNullableTypeWithBody()
+    {
+        $response = new MockResponse();
+        $response->setStatusCode(200);
+        $response->setBody(214);
+        $context = new Context(MockHelper::getClient()->getGlobalRequest(), $response, MockHelper::getClient());
+        $result = MockHelper::responseHandler()->nullableType()->getResult($context);
+        $this->assertEquals(214, $result);
+    }
+
+    public function testNonNullableTypeWithMissingBody()
+    {
+        $response = new MockResponse();
+        $response->setStatusCode(200);
+        $response->setBody('');
+        $context = new Context(MockHelper::getClient()->getGlobalRequest(), $response, MockHelper::getClient());
+        $result = MockHelper::responseHandler()->getResult($context);
+        $this->assertEquals('', $result);
+    }
+
+    public function testNonNullableTypeWithMissingBodyAndApiResponse()
+    {
+        $response = new MockResponse();
+        $response->setStatusCode(200);
+        $response->setBody('');
+        $context = new Context(MockHelper::getClient()->getGlobalRequest(), $response, MockHelper::getClient());
+        $result = MockHelper::responseHandler()->returnApiResponse()->getResult($context);
+        $this->assertInstanceOf(MockApiResponse::class, $result);
+        $this->assertEquals('', $result->getResult());
+        $this->assertFalse($result->isError());
+    }
+
+    public function testNonNullableTypeWithNullBody()
+    {
+        $response = new MockResponse();
+        $response->setStatusCode(200);
+        $response->setBody(null);
+        $context = new Context(MockHelper::getClient()->getGlobalRequest(), $response, MockHelper::getClient());
+        $result = MockHelper::responseHandler()->getResult($context);
+        $this->assertNull($result);
+    }
+
+    public function testNonNullableTypeWithBody()
+    {
+        $response = new MockResponse();
+        $response->setStatusCode(200);
+        $response->setBody(214);
+        $context = new Context(MockHelper::getClient()->getGlobalRequest(), $response, MockHelper::getClient());
+        $result = MockHelper::responseHandler()->getResult($context);
+        $this->assertEquals(214, $result);
     }
 
     public function testGlobalMockException()

--- a/tests/Mocking/Response/MockResponse.php
+++ b/tests/Mocking/Response/MockResponse.php
@@ -71,7 +71,7 @@ class MockResponse implements ResponseInterface
 
     public function getBody()
     {
-        return $this->body ?? ["res" => "This is raw body"];
+        return $this->body;
     }
 
     public function convert(ConverterInterface $converter)


### PR DESCRIPTION
## What
This PR adds complete support for returning nullable response types using the `nullableType()` builder function to set the response types as nullable.

## Why
Previously response handler was throwing an exception or returning `''` when a response with no content is received.

Closes #60

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
N/A

## Breaking change
N/A

## Testing
Unit tests have been added to test this feature

## Checklist
- [X] My code follows the coding conventions
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added new unit tests
