### PR TITLE
Feature/php84 compatible

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest] # windows-latest, macos-latest
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         include:
           - php: 7.2
             phpunit: 7
@@ -31,6 +31,10 @@ jobs:
             phpunit: 9
           - php: 8.2
             phpunit: 9
+          - php: 8.3
+            phpunit: 9
+          - php: 8.4
+            phpunit: 9            
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/src/Client.php
+++ b/src/Client.php
@@ -22,14 +22,14 @@ class Client
 {
     private static $converter;
     private static $jsonHelper;
-    public static function getConverter(Client $client = null): ConverterInterface
+    public static function getConverter(?Client $client = null): ConverterInterface
     {
         if (isset($client)) {
             return $client->localConverter;
         }
         return self::$converter;
     }
-    public static function getJsonHelper(Client $client = null): JsonHelper
+    public static function getJsonHelper(?Client $client = null): JsonHelper
     {
         if (isset($client)) {
             return $client->localJsonHelper;

--- a/src/Types/Sdk/CoreCallback.php
+++ b/src/Types/Sdk/CoreCallback.php
@@ -27,7 +27,7 @@ class CoreCallback
      * @param callable|null $onBeforeRequest Called before an API call
      * @param callable|null $onAfterRequest  Called after an API call
      */
-    public function __construct(callable $onBeforeRequest = null, callable $onAfterRequest = null)
+    public function __construct(?callable $onBeforeRequest = null, ?callable $onAfterRequest = null)
     {
         $this->onBeforeRequest = $onBeforeRequest;
         $this->onAfterRequest = $onAfterRequest;

--- a/src/Utils/XmlDeserializer.php
+++ b/src/Utils/XmlDeserializer.php
@@ -22,7 +22,7 @@ class XmlDeserializer
     /**
      * @param int|null $loadOptions  A bit field of LIBXML_* constants
      */
-    public function __construct(int $loadOptions = null)
+    public function __construct(?int $loadOptions = null)
     {
         $this->dom = new DOMDocument();
         $this->loadOptions = $loadOptions ?? (LIBXML_NONET | LIBXML_NOBLANKS);
@@ -81,7 +81,7 @@ class XmlDeserializer
         \DOMNode $parent,
         string $itemName,
         string $clazz,
-        string $wrappingElementName = null
+        ?string $wrappingElementName = null
     ) {
         if ($wrappingElementName === null) {
             $elements = static::getChildNodesByTagName($parent, $itemName);

--- a/src/Utils/XmlSerializer.php
+++ b/src/Utils/XmlSerializer.php
@@ -67,7 +67,7 @@ class XmlSerializer
         \DOMNode $root,
         string $itemName,
         $items,
-        string $wrappingElementName = null
+        ?string $wrappingElementName = null
     ): void {
         if ($items === null) {
             return;
@@ -102,7 +102,7 @@ class XmlSerializer
         return $element;
     }
 
-    public function createElement(string $name, string $value = null): \DOMElement
+    public function createElement(string $name, ?string $value = null): \DOMElement
     {
         return $value === null ? $this->dom->createElement($name) : $this->dom->createElement($name, $value);
     }


### PR DESCRIPTION
## What


## Why
add PHP 8.4 support

https://www.php.net/releases/8.4/en.php

In PHP 8.4, when using default arguments set to null, you are required to specify a type hint that includes either nullable or a union type with null. If this is not specified, a deprecated error will be displayed starting in PHP 8.4. This change is being addressed.
https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

Additionally, matrix build settings have been added to ensure the project is built across multiple PHP versions.


## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [ ] My code follows the coding conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
