### PR TITLE
feat(complex-headers): adds support to cater sending complex typed headers in requests

### DIFF
--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -158,7 +158,7 @@ class Request implements RequestSetterInterface
      */
     public function addHeader(string $key, $value): void
     {
-        $this->headers[$key] = $value;
+        $this->headers[$key] = CoreHelper::serialize($value);
     }
 
     /**

--- a/tests/ApiCallTest.php
+++ b/tests/ApiCallTest.php
@@ -147,6 +147,34 @@ class ApiCallTest extends TestCase
         $this->assertEquals(890.098, $request->getHeaders()['key5']);
     }
 
+    public function testComplexHeaderParams()
+    {
+        $request = (new RequestBuilder(RequestMethod::POST, '/some/path'))
+            ->parameters(
+                HeaderParam::init('class', new MockClass([
+                    'my string' => 'value',
+                ])),
+                HeaderParam::init('file', MockHelper::getFileWrapper()),
+                HeaderParam::init('array', ['my number' => 123]),
+                HeaderParam::init('false', false),
+                HeaderParam::init('true', true),
+                HeaderParam::init('number', 1234),
+                HeaderParam::init('string', 'value s')
+            )
+            ->build(MockHelper::getClient());
+
+        $this->assertEquals('{"body":{"my string":"value"}}', $request->getHeaders()['class']);
+        $this->assertEquals('{"my number":123}', $request->getHeaders()['array']);
+        $this->assertEquals(
+            'This test file is created to test CoreFileWrapper functionality',
+            $request->getHeaders()['file']
+        );
+        $this->assertEquals('false', $request->getHeaders()['false']);
+        $this->assertEquals('true', $request->getHeaders()['true']);
+        $this->assertEquals(1234, $request->getHeaders()['number']);
+        $this->assertEquals('value s', $request->getHeaders()['string']);
+    }
+
     public function testCollectedQueryParams()
     {
         $options = ['key1' => true, 'key2' => 'some string', 'key3' => 23];

--- a/tests/EndToEndTest.php
+++ b/tests/EndToEndTest.php
@@ -102,7 +102,7 @@ class EndToEndTest extends TestCase
             ->bodyMatcher(NativeBodyMatcher::init(TestParam::object('{"body":{"httpMethod":"POST","queryUrl":' .
                 '"https:\/\/my\/path\/v2\/api\/path\/poster?&date+array=Fri%2C+01+Oct+2021+00%3A00%3A00+GMT%2CThu' .
                 '%2C+30+Sep+2021+00%3A00%3A00+GMT&token=someAuthToken&authorization=accessToken","headers":{' .
-                '"additionalHead1":"headVal1","additionalHead2":"headVal2","header":1234,"token":"someAuthToken",' .
+                '"additionalHead1":"headVal1","additionalHead2":"headVal2","header":"1234","token":"someAuthToken",' .
                 '"authorization":"accessToken","Accept":"application\/json"},"parameters":{"form 2":{"key1":' .
                 '"value 1","key2":"false","key3":2.3}},"parametersEncoded":{' .
                 '"form 2":"form+2%5Bkey1%5D=value+1&form+2%5Bkey2%5D=false&form+2%5Bkey3%5D=2.3"},' .


### PR DESCRIPTION
## What
This PR updates the `Request::addHeader` function to use `CoreHelper::serialize` instead of direct string conversion, unit tests have been added to test this functionality

## Why
See the closing issue^

Closes #69 

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [X] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
N/A

## Breaking change
N/A

## Testing
Existing 

## Checklist
- [X] My code follows the coding conventions
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added new unit tests
