### PR TITLE
ci: migrate test coverage from CodeClimate to SonarCloud

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,11 +67,9 @@ jobs:
     - name: Run tests
       run: composer test-ci
 
-    - name: Upload coverage report
+    - name: SonarQube Scan
       if: ${{ matrix.os == 'ubuntu-latest' && matrix.php == '8.1' && github.actor != 'dependabot[bot]' }}
-      uses: paambaati/codeclimate-action@v3.0.0
+      uses: SonarSource/sonarqube-scan-action@v5.2.0
       env:
-        CC_TEST_REPORTER_ID: 3ee5e7a87dbd07c2616dfc72aada93a8d88684a483279f3995ab045190b5a811
-      with:
-        coverageLocations: |
-          ${{github.workspace}}/coverage-clover.xml:clover
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [![Version][packagist-version]][packagist-url]
 [![Tests][test-badge]][test-url]
-[![Test Coverage](https://api.codeclimate.com/v1/badges/90aa03dca1ef28d9cef3/test_coverage)](https://codeclimate.com/github/apimatic/core-lib-php/test_coverage)
-[![Maintainability](https://api.codeclimate.com/v1/badges/90aa03dca1ef28d9cef3/maintainability)](https://codeclimate.com/github/apimatic/core-lib-php/maintainability)
+[![Test Coverage][coverage-badge]][coverage-url]
+[![Maintainability Rating][maintainability-badge]][maintainability-url]
+[![Vulnerabilities][vulnerabilities-badge]][vulnerabilities-url]
 [![Licence][license-badge]][license-url]
 
 
@@ -82,5 +83,11 @@ composer require "apimatic/core"
 [packagist-downloads]: https://img.shields.io/packagist/dm/apimatic/core.svg?style=flat
 [test-badge]: https://github.com/apimatic/core-lib-php/actions/workflows/test.yml/badge.svg
 [test-url]: https://github.com/apimatic/core-lib-php/actions/workflows/test.yml
+[coverage-badge]: https://sonarcloud.io/api/project_badges/measure?project=apimatic_core-lib-php&metric=coverage
+[coverage-url]: https://sonarcloud.io/summary/new_code?id=apimatic_core-lib-php
+[maintainability-badge]: https://sonarcloud.io/api/project_badges/measure?project=apimatic_core-lib-php&metric=sqale_rating
+[maintainability-url]: https://sonarcloud.io/summary/new_code?id=apimatic_core-lib-php
+[vulnerabilities-badge]: https://sonarcloud.io/api/project_badges/measure?project=apimatic_core-lib-php&metric=vulnerabilities
+[vulnerabilities-url]: https://sonarcloud.io/summary/new_code?id=apimatic_core-lib-php
 [license-badge]: https://img.shields.io/badge/licence-MIT-blue
 [license-url]: LICENSE

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,10 @@
+sonar.projectKey=apimatic_core-lib-php
+sonar.projectName=APIMatic Core Library for PHP
+sonar.organization=apimatic
+sonar.host.url=https://sonarcloud.io
+sonar.sourceEncoding=UTF-8
+
+sonar.sources=src
+sonar.tests=tests
+
+sonar.php.coverage.reportPaths=coverage-clover.xml


### PR DESCRIPTION
This PR migrates the coverage reporting from Code Climate to SonarCloud. It also adds badges from SonarCloud in Readme.